### PR TITLE
Cherry pick up/down vote button interactive from alpha to main

### DIFF
--- a/winston/components/Links/CommentLink/CommentLinkContent.swift
+++ b/winston/components/Links/CommentLink/CommentLinkContent.swift
@@ -118,6 +118,7 @@ struct CommentLinkContent: View {
               HStack(alignment: .center, spacing: 4) {
                 Image(systemName: "arrow.up")
                   .foregroundColor(data.likes != nil && data.likes! ? .orange : .gray)
+                  .contentShape(Rectangle())
                   .onTapGesture {
                       Task { _ = await comment.vote(action: .up) }
                   }
@@ -132,6 +133,7 @@ struct CommentLinkContent: View {
 
                 Image(systemName: "arrow.down")
                   .foregroundColor(data.likes != nil && !data.likes! ? .blue : .gray)
+                  .contentShape(Rectangle())
                   .onTapGesture {
                       Task { _ = await comment.vote(action: .down) }
                   }

--- a/winston/components/Links/CommentLink/CommentLinkContent.swift
+++ b/winston/components/Links/CommentLink/CommentLinkContent.swift
@@ -118,17 +118,23 @@ struct CommentLinkContent: View {
               HStack(alignment: .center, spacing: 4) {
                 Image(systemName: "arrow.up")
                   .foregroundColor(data.likes != nil && data.likes! ? .orange : .gray)
-
+                  .onTapGesture {
+                      Task { _ = await comment.vote(action: .up) }
+                  }
+                  
                 let downup = Int(ups)
                 Text(formatBigNumber(downup))
                   .foregroundColor(data.likes != nil ? (data.likes! ? .orange : .blue) : .gray)
                   .contentTransition(.numericText())
-                  
+
                 //                  .foregroundColor(downup == 0 ? .gray : downup > 0 ? .orange : .blue)
                   .fontSize(14, .semibold)
 
                 Image(systemName: "arrow.down")
                   .foregroundColor(data.likes != nil && !data.likes! ? .blue : .gray)
+                  .onTapGesture {
+                      Task { _ = await comment.vote(action: .down) }
+                  }
               }
               .fontSize(14, .medium)
               .padding(.horizontal, 6)


### PR DESCRIPTION
This is a cherry pick of #73 from alpha to main. A small feature improvement to add the upvote / downvote task when tapping the upvote / downvote buttons in the comments. 

This has been in alpha for a few weeks ago and due to simplicity of code changes / personally testing I have decided that I might try and merge it into main, to help reduce the amount of conflicts within #75 🤯

A gif of the functionality is as follows:
![Screen Recording 2023-10-03 at 12 17 58 am](https://github.com/Kinark/winston/assets/92675290/bf94ab30-edb2-4ef5-b876-e25d3b675bb0)

Summary of feature include:
Comments can be upvoted / downvoted on tap. 
apping the "arrow area" on a collapsed comment will have no effect, and rather just uncollapse the comment.
Tapping same button twice, casts, then removes, vote ect.

Also as per discord suggestion by @Frostplexx and @ojsef39 I have increased the hitbox around the arrows.
<img width="687" alt="image" src="https://github.com/Kinark/winston/assets/92675290/267d3e2d-9735-4ff9-bef5-246158f84faa">

Design wise this looks exactly the same.
