### PR TITLE
Change UI of the app icon selector

### DIFF
--- a/winston/views/Settings/views/AppIconSetting.swift
+++ b/winston/views/Settings/views/AppIconSetting.swift
@@ -38,12 +38,17 @@ struct AppIconSetting: View {
               
               //              Spacer()
               
-              Toggle("", isOn: Binding(
-                get: { icon == appIcon },
-                set: { _ in appIcon = icon }))
+                if(icon == appIcon)
+                {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.accentColor)
+                }
             }
           }
           .themedListRowBG(enablePadding: true)
+          .onTapGesture {
+              appIcon = icon
+          }
         }
       }
       .themedListDividers()


### PR DESCRIPTION
Small UI change. The recently added App Icon settings came with a toggle to pick the app icon.
I feel more standard UI practice would be to have a checkmark, as a Toggle would indicate multiple options are available at the same time, but that isn't really the case.

A checkmark could also potentially be more useful for things such as accessibility, a user with a vision impairment might not be able to see the toggles changing on / off and be confused by the behaviour. Whereas the checkmark might be more easy to understand, and matches the standard practice.

| Before | After |
|--------|--------|
| ![IMG_7629](https://github.com/Kinark/winston/assets/92675290/3466898e-0b6a-421d-b264-436a2fd0998a) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-03 at 19 18 49](https://github.com/Kinark/winston/assets/92675290/0b04ef60-b7d7-4048-b728-721c683e460b)

Video of usage
![Screen Recording 2023-10-03 at 7 19 44 pm](https://github.com/Kinark/winston/assets/92675290/b9093cd2-f51f-43de-ae8c-08fcd095fafa)

The checkmark changes colour based on the theming settings (whatever the accent colour is set too). The UI matches that of the iOS settings app > ringtones. Just a simple checkmark systemImage.

If this design change isn't appreciated, and if the choice of a toggle was something to do with your personal branding / design style I understand, and feel free to reject this pull request :)) 