### PR TITLE
infra: add automated build with GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,92 @@
+name: Build winston
+
+on:
+  push:
+    branches:
+      - alpha
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0'
+
+      - name: Install the Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      - name: Build Xcode archive
+        env:
+          TEAM_ID: ${{ secrets.DEVELOPMENT_TEAM_ID }}
+        run: |
+          xcodebuild \
+            -scheme "winston" \
+            -archivePath $RUNNER_TEMP/winston.xcarchive \
+            -sdk iphoneos \
+            -destination platform=iOS \
+            -allowProvisioningUpdates \
+            DEVELOPMENT_TEAM=$TEAM_ID \
+            clean archive
+
+      - name: Export ipa
+        env:
+          EXPORT_OPTIONS_PLIST: ${{ secrets.EXPORT_OPTIONS_PLIST }}
+        run: |
+          EXPORT_OPTS_PATH=$RUNNER_TEMP/ExportOptions.plist
+          echo -n "$EXPORT_OPTIONS_PLIST" | base64 --decode -o $EXPORT_OPTS_PATH
+          xcodebuild -exportArchive -archivePath $RUNNER_TEMP/winston.xcarchive -exportOptionsPlist $EXPORT_OPTS_PATH -exportPath $RUNNER_TEMP/build
+
+      - name: Clean up keychain and provisioning profile
+        if: ${{ always() }}
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+          rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
+
+      - name: Upload to Github Releases
+        uses: actions/upload-artifact@v3
+        with:
+          name: winston-nightly
+          path: ${{ runner.temp }}/build/winston.ipa
+          retention-days: 3
+
+      - name: 'Upload to TestFlight'
+        uses: apple-actions/upload-testflight-build@v1
+        if: ${{ false }}
+        with:
+          app-path: '${{ runner.temp }}/build/winston.ipa'
+          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}


### PR DESCRIPTION
**_This pull request is still a draft and subject to changes._** 

This pull request adds automated builds with GitHub Actions. To perform an automated build, the following secrets are needed:
* `BUILD_CERTIFICATE_BASE64`: Base64 encoded build certificate
* `P12_PASSWORD`: Password for the P12 certificate (defined when exporting certificate from Keychain Access)
* `BUILD_PROVISION_PROFILE_BASE64`: Base64 encoded provisioning profile for winston
* `KEYCHAIN_PASSWORD`: A customized temporary Keychain password, could be random strong passwords
* `DEVELOPMENT_TEAM_ID`: The developer team ID from App Store Connect
* `APPSTORE_ISSUER_ID`, `APPSTORE_API_KEY_ID`, `APPSTORE_API_PRIVATE_KEY`: API credentials for automated TestFlight upload
* `EXPORT_OPTIONS_PLIST`: Base64 encoded IPA Export options plist 

Advice and edits are welcome. It's also possible to perform unsigned IPA builds without any of the credentials (`EXPORT_OPTIONS_PLIST` is still needed though). 

References: 
[Installing an Apple certificate on macOS runners for Xcode development](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development)