### PR TITLE
fix(comments): fix for comments being cut off

### DIFF
--- a/winston/components/Links/CommentLink/CommentLinkContent.swift
+++ b/winston/components/Links/CommentLink/CommentLinkContent.swift
@@ -224,7 +224,7 @@ struct CommentLinkContent: View {
                     Text(body.md())
                       .lineLimit(lineLimit)
                   } else {
-                    MD2(data.winstonBodyAttrEncoded == nil ? .str(body) : .json(data.winstonBodyAttrEncoded!), fontSize: theme.theme.bodyText.size)
+                    MD(data.winstonBodyAttrEncoded == nil ? .str(body) : .json(data.winstonBodyAttrEncoded!), fontSize: theme.theme.bodyText.size)
                         .lineSpacing(theme.theme.linespacing)
                       .fixedSize(horizontal: false, vertical: true)
                       .overlay(


### PR DESCRIPTION
Idk why this fixes the issue / why `MD2` caused the issue, just saw it was different than `main` and then it started working once I changed it to `MD`