### PR TITLE
Add ability to filter for user posts OR comments exclusively on user view

### DIFF
--- a/winston/models/RedditAPI/user/fetchUserOverview.swift
+++ b/winston/models/RedditAPI/user/fetchUserOverview.swift
@@ -9,21 +9,43 @@ import Foundation
 import Alamofire
 
 extension RedditAPI {
-  func fetchUserOverview(_ userName: String, _ after: String? = nil) async -> [Either<PostData, CommentData>]? {
+  func fetchUserOverview(_ userName: String, _ dataTypeFilter: String? = nil, _ after: String? = nil) async -> [Either<PostData, CommentData>]? {
     await refreshToken()
     if let headers = self.getRequestHeaders() {
-      var requestURL = "\(RedditAPI.redditApiURLBase)/user/\(userName)/overview.json"
-      if let after = after {
-        requestURL += "?after=\(after)"
+      var endpoint: String
+
+      if let dataTypeFilter = dataTypeFilter, !dataTypeFilter.isEmpty {
+        if dataTypeFilter.lowercased() == "posts" {
+          endpoint = "\(RedditAPI.redditApiURLBase)/user/\(userName)/submitted.json"
+        } else if dataTypeFilter.lowercased() == "comments" {
+          endpoint = "\(RedditAPI.redditApiURLBase)/user/\(userName)/comments.json"
+        } else {
+          print("Invalid dataTypeFilter")
+          return nil
+        }
+      } else {
+        endpoint = "\(RedditAPI.redditApiURLBase)/user/\(userName)/overview.json"
       }
-      
+
+      var urlComponents = URLComponents(string: endpoint)!
+
+      if let after = after {
+        urlComponents.queryItems = [URLQueryItem(name: "after", value: after)]
+      }
+
+      guard let requestURL = urlComponents.url else {
+        print("Error: Unable to create a valid URL")
+        return nil
+      }
+
+      print(requestURL)
+
       let response = await AF.request(
         requestURL,
         method: .get,
         headers: headers
       )
       .serializingDecodable(Listing<Either<PostData, CommentData>>.self).response
-      
       switch response.result {
       case .success(let data):
         return data.data?.children?.map { $0.data }.compactMap { $0 }

--- a/winston/models/User.swift
+++ b/winston/models/User.swift
@@ -21,8 +21,8 @@ extension User {
     self.init(id: id, api: api, typePrefix: "\(User.prefix)_")
   }
   
-  func refetchOverview(_ after: String? = nil) async -> [Either<Post, Comment>]? {
-    if let name = data?.name, let overviewData = await RedditAPI.shared.fetchUserOverview(name, after) {
+  func refetchOverview(_ dataTypeFilter: String? = nil, _ after: String? = nil) async -> [Either<Post, Comment>]? {
+    if let name = data?.name, let overviewData = await RedditAPI.shared.fetchUserOverview(name, dataTypeFilter, after) {
       await MainActor.run {
         self.loading = false
       }

--- a/winston/views/Users/UserView.swift
+++ b/winston/views/Users/UserView.swift
@@ -247,6 +247,7 @@ struct UserView: View {
               .progressViewStyle(.circular)
               .frame(maxWidth: .infinity, minHeight: 100 )
               .id("post-loading")
+              .id(UUID()) // spawns unique spinner, swiftui bug.
           }
         }
         .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
@@ -272,6 +273,11 @@ struct UserView: View {
       }
     }
     .onChange(of: dataTypeFilter) { _ in
+      withAnimation {
+        lastActivities?.removeAll()
+        loadingOverview = true
+      }
+      
       Task {
         await refresh()
       }


### PR DESCRIPTION
- extends functionality of api call to support submissions and comments explicitly (retains infinite scrolling ability)
- add functionality to post/comment karma button that filters user data feed
- adds spinner when selecting new filter
- clears feed when new filter is selected