### PR TITLE
video player stability fixes and some other minor tweaks

### DIFF
--- a/winston/components/GlobalLoader.swift
+++ b/winston/components/GlobalLoader.swift
@@ -45,7 +45,7 @@ class GlobalLoader: ObservableObject {
   
   func enable(_ str: String) {
     self.loadingText = str
-    doThisAfter(0) {
+    doThisAfter(0.0) {
       withAnimation(spring) {
         self.showing = true
       }

--- a/winston/components/LightBoxImage/LightBoxImage.swift
+++ b/winston/components/LightBoxImage/LightBoxImage.swift
@@ -178,7 +178,7 @@ struct LightBoxImage: View {
       if lightboxViewsPost { Task(priority: .background) { await markAsSeen?() } }
       xPos = -CGFloat(i) * (UIScreen.screenWidth + SPACING)
       activeIndex = i
-      doThisAfter(0) {
+      doThisAfter(0.0) {
         withAnimation(.easeOut) {
           appearContent = true
           appearBlack = true

--- a/winston/components/Modals/NewPostModal.swift
+++ b/winston/components/Modals/NewPostModal.swift
@@ -94,7 +94,7 @@ struct FlairPicker: View {
               withAnimation(spring) {
                 searching = true
               }
-              doThisAfter(0) {
+              doThisAfter(0.0) {
                 focused = true
               }
             } label: {
@@ -172,7 +172,7 @@ struct FlairPicker: View {
       .onChange(of: focused) { newValue in
         if !newValue {
           withAnimation(spring) { searching = false }
-          doThisAfter(0) {
+          doThisAfter(0.0) {
             withAnimation {
               searchQuery.text = ""
               searchQuery.debounced = ""

--- a/winston/components/replyModalPresenter.swift
+++ b/winston/components/replyModalPresenter.swift
@@ -47,21 +47,21 @@ class ReplyModalInstance: ObservableObject {
     switch subject {
     case .commentEdit(let comment):
       subjectCommentEdit = comment
-      doThisAfter(0) {
+      doThisAfter(0.0) {
         withAnimation(spring) {
           self.isShowing = .commentEdit
         }
       }
     case .comment(let comment):
       subjectComment = comment
-      doThisAfter(0) {
+      doThisAfter(0.0) {
         withAnimation(spring) {
           self.isShowing = .comment
         }
       }
     case .post(let post):
       subjectPost = post
-      doThisAfter(0) {
+      doThisAfter(0.0) {
         withAnimation(spring) {
           self.isShowing = .post
         }

--- a/winston/models/RedditAPI/user/fetchUsers.swift
+++ b/winston/models/RedditAPI/user/fetchUsers.swift
@@ -56,7 +56,9 @@ extension RedditAPI {
         switch subject {
         case .first(let post):
           if let author = post.data?.author_fullname {
-            post.winstonData?.avatarImageRequest = avatarsDict[author]
+            DispatchQueue.main.async {
+              post.winstonData?.avatarImageRequest = avatarsDict[author]
+            }
           }
         case .second(let comment):
           if let authorFullname = comment.data?.author_fullname {

--- a/winston/modifiers/SwipeAnywhere.swift
+++ b/winston/modifiers/SwipeAnywhere.swift
@@ -23,7 +23,7 @@ class SwipeAnywhereRouterContainer: ObservableObject {
   
   init(_ router: Router) {
     self.router = router
-    doThisAfter(0) {
+    doThisAfter(0.0) {
       self.cancellable = self.router.objectWillChange.sink { [weak self] val in
         let isIt = self?.router.path.count == 0
         if self?.isRoot != isIt { self?.isRoot = isIt }

--- a/winston/views/Announcements/TestersCelebration.swift
+++ b/winston/views/Announcements/TestersCelebration.swift
@@ -169,7 +169,7 @@ struct TestersCelebration: View {
     .confettiCannon(counter: $counter, num: 30, openingAngle: Angle.degrees(60), closingAngle: Angle.degrees(120), radius: UIScreen.screenWidth)
     .onAppear {
       if showTipJarModal { showTipJarModal = false }
-      doThisAfter(1) { withAnimation { counter += 1 } }
+      doThisAfter(1.0) { withAnimation { counter += 1 } }
     }
     .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
       if thanks { doThisAfter(0.25) { withAnimation { counter += 1 } } }

--- a/winston/views/ChangeAuthAPIKey.swift
+++ b/winston/views/ChangeAuthAPIKey.swift
@@ -106,7 +106,7 @@ struct CopiableValue: View {
         withAnimation {
           copied = true
         }
-        doThisAfter(1) {
+        doThisAfter(1.0) {
           withAnimation {
             copied = false
           }

--- a/winston/views/MultiPostsView.swift
+++ b/winston/views/MultiPostsView.swift
@@ -106,7 +106,7 @@ struct MultiPostsView: View {
     )
     .onAppear {
       if posts.data.count == 0 {
-        doThisAfter(0) {
+        doThisAfter(0.0) {
           fetch()
         }
       }

--- a/winston/views/Onboarding/Steps/OnboardingWelcome.swift
+++ b/winston/views/Onboarding/Steps/OnboardingWelcome.swift
@@ -76,11 +76,11 @@ struct OnboardingWelcome: View {
               withAnimation(spring) {
                 showHello = true
               }
-              doThisAfter(1) {
+              doThisAfter(1.0) {
                 withAnimation(spring) {
                   showAppName = true
                 }
-                doThisAfter(1) {
+                doThisAfter(1.0) {
                   withAnimation(spring) {
                     showText = true
                   }


### PR DESCRIPTION
 - Used [weak self] to prevent strong reference cycles.
- Moved the doThisAfter function outside the class for better organization.
- Check for self existence before performing actions inside closure to avoid potential crashes.
- Ensured optional chaining and optional binding to handle optional values more safely.
- Some other minor tweaks for better Swift conventions and readability.
- Fixed warning that would publish changes from the background thread. (Not Allowed)