### PR TITLE
Fixed missing cell padding for compact post titles

### DIFF
--- a/winston/components/Links/PostLink/getPostContentWidth.swift
+++ b/winston/components/Links/PostLink/getPostContentWidth.swift
@@ -140,7 +140,7 @@ func getPostDimensions(post: Post, winstonData: PostWinstonData? = nil, columnWi
       }
     }
     
-    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + (showSelfPostThumbnails || extractedMedia != nil ? postGeneralSpacing + compactMediaSize.width : 0)
+    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + postGeneralSpacing + compactMediaSize.width
     
     let titleContentWidth = contentWidth - (compact ? compactTitleWidth : 0)
     


### PR DESCRIPTION
Fixes #309 

Title width should likely be fixed regardless. `compactMediaSize` is also fixed even if there's no media.

Before:
![image](https://github.com/lo-cafe/winston/assets/218731/1417600e-4856-4b1d-8ff3-812c80ea8f8f)

After:
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 34 43](https://github.com/lo-cafe/winston/assets/152220723/e2160e18-2196-407b-ad89-c571dc5566a2)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 05](https://github.com/lo-cafe/winston/assets/152220723/af437f14-195d-4f83-ae0b-00a3cc932f1f)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 44](https://github.com/lo-cafe/winston/assets/152220723/b5087c03-5406-4e05-a992-bb36d736d2d6)
