### PR TITLE
Fixed missing cell padding for compact post titles

### DIFF
--- a/winston/components/Links/PostLink/getPostContentWidth.swift
+++ b/winston/components/Links/PostLink/getPostContentWidth.swift
@@ -140,7 +140,7 @@ func getPostDimensions(post: Post, winstonData: PostWinstonData? = nil, columnWi
       }
     }
     
-    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + (showSelfPostThumbnails || extractedMedia != nil ? postGeneralSpacing + compactMediaSize.width : 0)
+    let compactTitleWidth = postGeneralSpacing + VotesCluster.verticalWidth + postGeneralSpacing + compactMediaSize.width
     
     let titleContentWidth = contentWidth - (compact ? compactTitleWidth : 0)
     


### PR DESCRIPTION
Fixes #313 309

Title width should likely be fixed regardless. compactMediaSize is also fixed even if there's no media.

![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 44](https://github.com/lo-cafe/winston/assets/152220723/c33729aa-0694-4e3c-90ff-e573887938f9)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 35 05](https://github.com/lo-cafe/winston/assets/152220723/e1dc263e-60d2-4886-b85b-016b7b0204db)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-28 at 12 34 43](https://github.com/lo-cafe/winston/assets/152220723/46d1362b-473a-45a9-8ccd-67d47d3c00ca)
