### PR TITLE
next attempt to solve video playback with background music

### DIFF
--- a/winston/AppDelegate.swift
+++ b/winston/AppDelegate.swift
@@ -62,18 +62,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ImagePipeline.shared = defaultPipeline
   }
   
-  func setAudioToMixWithOthers() {
-    do {
-      let audioSession = AVAudioSession.sharedInstance()
-      try audioSession.setCategory(.ambient, options: [.mixWithOthers])
-    } catch {
-      print("Error setting audio session to mix with others")
-    }
-  }
+  
 }
 
 class CustomSceneDelegate: UIResponder, UIWindowSceneDelegate {
   func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
     shortcutItemToProcess = shortcutItem
   }
+}
+
+public func setAudioToMixWithOthers(_ activateplayback: Bool = false) {
+	do {
+		let audioSession = AVAudioSession.sharedInstance()
+		if (activateplayback == true) {
+			try audioSession.setCategory(.playback, mode: AVAudioSession.Mode.default, options: [.mixWithOthers])
+			try audioSession.setActive(true)
+		} else {
+			try audioSession.setCategory(.ambient, options: [.mixWithOthers])
+			try audioSession.setActive(false, options: AVAudioSession.SetActiveOptions.notifyOthersOnDeactivation)
+		}
+	} catch {
+		print("Error setting audio session to mix with others")
+	}
 }

--- a/winston/components/Media/VideoPlayerPost.swift
+++ b/winston/components/Media/VideoPlayerPost.swift
@@ -91,6 +91,7 @@ struct VideoPlayerPost: View, Equatable {
     let finalHeight = maxPostLinkImageHeightPercentage != 110 ? Double(min(maxHeight, propHeight)) : Double(propHeight)
     
     if let sharedVideo = sharedVideo {
+			var hasAudio = sharedVideo.player.currentItem?.tracks.contains(where: {$0.assetTrack?.mediaType == AVMediaType.audio})
       if let controller = controller {
         AVPlayerRepresentable(fullscreen: $fullscreen, autoPlayVideos: autoPlayVideos, player: sharedVideo.player, aspect: .resizeAspectFill, controller: controller)
           .frame(width: compact ? scaledCompactModeThumbSize() : contentWidth, height: compact ? scaledCompactModeThumbSize() : CGFloat(finalHeight))
@@ -137,6 +138,9 @@ struct VideoPlayerPost: View, Equatable {
 							sharedVideo.player.pause()
 							firstFullscreen = false
 						}
+						if sharedVideo.player.isMuted == false && hasAudio == true {
+							setAudioToMixWithOthers(val)
+						}
             sharedVideo.player.volume = val ? 1.0 : 0.0
           }
           .allowsHitTesting(false)
@@ -180,6 +184,9 @@ struct VideoPlayerPost: View, Equatable {
 						sharedVideo.player.pause()
 						firstFullscreen = false
 					 }
+					if sharedVideo.player.isMuted == false && hasAudio == true {
+						setAudioToMixWithOthers(val)
+					}
           sharedVideo.player.volume = val ? 1.0 : 0.0
         }
         .fullScreenCover(isPresented: $fullscreen) {


### PR DESCRIPTION
### Description
Next attempt to solve the video playback issue with background audio.

### Explanation
- sets AudioSession to playback on demand
- checks, if video has audio, else no playback --> background music stays active
- if video has audio and not muted --> on enter fullscreen set playback, background music pauses and resumes on leave fullscreen
- works in silent mode too

### Shortcomings
- currently no check for mute/unmute in AVPlayer itself