### PR TITLE
Fix Face ID Auth in Alpha

### DIFF
--- a/winston/views/Settings/views/BehaviorPanel.swift
+++ b/winston/views/Settings/views/BehaviorPanel.swift
@@ -31,7 +31,7 @@ struct BehaviorPanel: View {
           Toggle("Open Youtube Videos Externally", isOn: $behaviorDefSettings.openYoutubeApp)
           let auth_type = Biometrics().biometricType()
           Toggle("Lock Winston With \(auth_type)", isOn: $generalDefSettings.useAuth)
-//
+
           VStack{
             Toggle("Live Text Analyzer", isOn: $behaviorDefSettings.doLiveText)
               .disabled(!imageAnalyzerSupport)


### PR DESCRIPTION
Moves FaceID options to `GeneralDefSettings` which is why it wasn't working. Improves logic and adds a few comments/removes whitespace.

Fixes:
https://github.com/lo-cafe/winston/issues/368
https://github.com/lo-cafe/winston/issues/316
https://github.com/lo-cafe/winston/issues/314