### PR TITLE
Disable Face ID Auth Option on MacOS

### DIFF
--- a/winston/views/AppContent.swift
+++ b/winston/views/AppContent.swift
@@ -39,9 +39,15 @@ struct AppContent: View {
     .environment(\.useTheme, selectedTheme)
     .onAppear { themesDefSettings.themesPresets = themesDefSettings.themesPresets.filter { $0.id != "default" } }
     .onChange(of: scenePhase) { newPhase in
+      // No auth on MacOS
+      var runningOnMac = false
+      #if os(macOS)
+        runningOnMac = true
+      #endif
+
       let useAuth = generalDefSettings.useAuth // Get fresh value
       
-      if (useAuth) {
+      if (useAuth && !runningOnMac) {
         if (!isAuthenticating && newPhase == .active && lockBlur != 0){
           // Not authing, active and blur visible = Need to auth
           isAuthenticating = true

--- a/winston/views/Settings/views/BehaviorPanel.swift
+++ b/winston/views/Settings/views/BehaviorPanel.swift
@@ -31,7 +31,7 @@ struct BehaviorPanel: View {
           Toggle("Open Youtube Videos Externally", isOn: $behaviorDefSettings.openYoutubeApp)
           let auth_type = Biometrics().biometricType()
           Toggle("Lock Winston With \(auth_type)", isOn: $generalDefSettings.useAuth)
-//
+
           VStack{
             Toggle("Live Text Analyzer", isOn: $behaviorDefSettings.doLiveText)
               .disabled(!imageAnalyzerSupport)

--- a/winston/views/Settings/views/BehaviorPanel.swift
+++ b/winston/views/Settings/views/BehaviorPanel.swift
@@ -29,8 +29,10 @@ struct BehaviorPanel: View {
         Section("General") {
           Toggle("Open links in Safari", isOn: $behaviorDefSettings.openLinksInSafari)
           Toggle("Open Youtube Videos Externally", isOn: $behaviorDefSettings.openYoutubeApp)
-          let auth_type = Biometrics().biometricType()
-          Toggle("Lock Winston With \(auth_type)", isOn: $generalDefSettings.useAuth)
+          #if !os(macOS)
+            let auth_type = Biometrics().biometricType()
+            Toggle("Lock Winston With \(auth_type)", isOn: $generalDefSettings.useAuth)
+          #endif
 
           VStack{
             Toggle("Live Text Analyzer", isOn: $behaviorDefSettings.doLiveText)


### PR DESCRIPTION
Disables the ability to lock Winston when running on MacOS since auth fails or can completely lock the user out if enabled.

Fixes https://github.com/lo-cafe/winston/issues/304