### PR TITLE
Add paste button for token in advanced mode [Proper PR]

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1814,6 +1814,9 @@
     "If it's taking too long, tap cancel and try again." : {
 
     },
+    "If it's taking too long, tap cancel and try again. Or you can press the button below to paste the URL reddit redirected you to." : {
+
+    },
     "Import Settings" : {
       "localizations" : {
         "de" : {
@@ -2684,6 +2687,9 @@
         }
       }
     },
+    "Paste" : {
+
+    },
     "Paste here the app ID" : {
       "localizations" : {
         "de" : {
@@ -2717,6 +2723,9 @@
       }
     },
     "Pause background audio on fullscreen" : {
+
+    },
+    "Pinned" : {
 
     },
     "Placeholder image" : {
@@ -3723,6 +3732,9 @@
 
     },
     "The authorization flow didn't work. Please tap the error button and try again or use another credential." : {
+
+    },
+    "The clipboard contains no URLs. Make sure to have properly copied the URL, tap the error button and try again." : {
 
     },
     "The credentials seem to be valid, but we need you to authorize the credentials to access your account *(yeah, it sounds redundand, sorry)*." : {

--- a/winston/models/RedditAPI/RedditAPI.swift
+++ b/winston/models/RedditAPI/RedditAPI.swift
@@ -183,8 +183,9 @@ class RedditAPI {
         return false
     }
     
-    func getAuthCodeFromURL(_ rawUrl: URL) -> String? {
-        if let url = URL(string: rawUrl.absoluteString.replacingOccurrences(of: "winstonapp://", with: "https://app.winston.cafe/")), url.lastPathComponent == "auth-success", let query = URLComponents(url: url, resolvingAgainstBaseURL: false), let state = query.queryItems?.first(where: { $0.name == "state" })?.value, let code = query.queryItems?.first(where: { $0.name == "code" })?.value, state == lastAuthState {
+    /// This function is preferred when the URL to be evaluated is already the app.winston.cafe URL with https scheme
+    func getAuthCodeFromURL(_ url: URL) -> String? {
+      if ((url.scheme == "https" && url.host() == "app.winston.cafe") || url.scheme == "winstonapp"), url.lastPathComponent == "auth-success", let query = URLComponents(url: url, resolvingAgainstBaseURL: false), let state = query.queryItems?.first(where: { $0.name == "state" })?.value, let code = query.queryItems?.first(where: { $0.name == "code" })?.value, state == lastAuthState {
             //      let res = await injectFirstAccessTokenInto(&credential, authCode: code)
             //      lastAuthState = nil
             //      return res
@@ -193,6 +194,15 @@ class RedditAPI {
             return nil
         }
     }
+  
+//    /// This function is preferred when the URL to be evaluated is already the app.winston.cafe URL with https scheme
+//    func getAuthCodeFromURLWithHTTPS(_ url: URL) -> String? {
+//      if url.lastPathComponent == "auth-success", let query = URLComponents(url: url, resolvingAgainstBaseURL: false), let state = query.queryItems?.first(where: { $0.name == "state" })?.value, let code = query.queryItems?.first(where: { $0.name == "code" })?.value, state == lastAuthState {
+//        return code
+//      } else {
+//        return nil
+//      }
+//    }
     
     func  getAuthorizationCodeURL(_ appID: String) -> URL {
         let response_type: String = "code"


### PR DESCRIPTION
Adds the ability to paste the token from the clipboard once redirected to the Winston callback URI when trying to add tokens in advanced mode. I had a couple problems with the safari extension working unexpectedly and this helped with development where app links couldn't be used (for some reason or another, not sure). Additionally, if one needs to copy the token from another device, this simplifies it. Either way, I think it would be a nice addition to have as a fallback.

LMK if I should add some screenshots

_P.S. I accidentally created the wrong PR in #537 merging into base. Hence my new PR into alpha._